### PR TITLE
lineage-sdk lights: Let Lineage lights decide if notification led is …

### DIFF
--- a/sdk/src/java/org/lineageos/internal/notification/LineageNotificationLights.java
+++ b/sdk/src/java/org/lineageos/internal/notification/LineageNotificationLights.java
@@ -63,6 +63,7 @@ public final class LineageNotificationLights {
     private boolean mAutoGenerateNotificationColor;
     private boolean mScreenOnEnabled;
     private boolean mZenAllowLights;
+    private boolean mNotificationLedEnabled;
     private int mNotificationLedBrightnessLevel;
     private int mNotificationLedBrightnessLevelZen;
     private int mDefaultNotificationColor;
@@ -268,8 +269,14 @@ public final class LineageNotificationLights {
 
         final boolean enableLed;
         if (forcedOn) {
-            // Forced on always enables
+            // Forced on always enables.
+            // This is even higher priority than mNotificationLedEnabled (user
+            // led on/off setting) so that the battery light picker can still
+            // be used if notification led is turned off in settings.
             enableLed = true;
+        } else if (!mNotificationLedEnabled) {
+            // Notification light on/off user setting
+            enableLed = false;
         } else if (!mZenAllowLights && mZenMode != Global.ZEN_MODE_OFF) {
             // DnD configured to disable lights in all modes (except when off).
             enableLed = false;
@@ -335,6 +342,9 @@ public final class LineageNotificationLights {
         void observe() {
             ContentResolver resolver = mContext.getContentResolver();
 
+            resolver.registerContentObserver(Settings.System.getUriFor(
+                    Settings.System.NOTIFICATION_LIGHT_PULSE),
+                    false, this, UserHandle.USER_ALL);
             resolver.registerContentObserver(LineageSettings.System.getUriFor(
                     LineageSettings.System.NOTIFICATION_LIGHT_PULSE_DEFAULT_COLOR),
                     false, this, UserHandle.USER_ALL);
@@ -381,6 +391,11 @@ public final class LineageNotificationLights {
         private void update() {
             ContentResolver resolver = mContext.getContentResolver();
             Resources res = mContext.getResources();
+
+            // Whether the notification led is enabled
+            mNotificationLedEnabled = Settings.System.getIntForUser(resolver,
+                    Settings.System.NOTIFICATION_LIGHT_PULSE,
+                    0, UserHandle.USER_CURRENT) != 0;
 
             // Automatically pick a color for LED if not set
             mAutoGenerateNotificationColor = LineageSettings.System.getIntForUser(resolver,


### PR DESCRIPTION
…on/off

*) Allows us to cater for the case where the notification led is turned off
   and yet the user wants to adjust battery light settings (which requires
   posting led notifications to illustrate the change).

Change-Id: I24d128d796a44f5b3e9051d441427cc19e2a3822