### PR TITLE
sdk: Remove low power restrictions on color control

### DIFF
--- a/lineage/lib/main/java/org/lineageos/platform/internal/display/ColorTemperatureController.java
+++ b/lineage/lib/main/java/org/lineageos/platform/internal/display/ColorTemperatureController.java
@@ -186,7 +186,7 @@ public class ColorTemperatureController extends LiveDisplayFeature {
         int temperature = mDayTemperature;
         int mode = getMode();
 
-        if (mode == MODE_OFF || isLowPowerMode()) {
+        if (mode == MODE_OFF) {
             temperature = mDefaultDayTemperature;
         } else if (mode == MODE_NIGHT) {
             temperature = mNightTemperature;

--- a/lineage/lib/main/java/org/lineageos/platform/internal/display/DisplayHardwareController.java
+++ b/lineage/lib/main/java/org/lineageos/platform/internal/display/DisplayHardwareController.java
@@ -250,12 +250,10 @@ public class DisplayHardwareController extends LiveDisplayFeature {
 
         final float[] rgb = getDefaultAdjustment();
 
-        if (!isLowPowerMode()) {
-            copyColors(mColorAdjustment, rgb);
-            rgb[0] *= mAdditionalAdjustment[0];
-            rgb[1] *= mAdditionalAdjustment[1];
-            rgb[2] *= mAdditionalAdjustment[2];
-        }
+        copyColors(mColorAdjustment, rgb);
+        rgb[0] *= mAdditionalAdjustment[0];
+        rgb[1] *= mAdditionalAdjustment[1];
+        rgb[2] *= mAdditionalAdjustment[2];
 
         if (DEBUG) {
             Slog.d(TAG, "updateColorAdjustment: " + Arrays.toString(rgb));


### PR DESCRIPTION
* We no longer support the GPU backed, power hungry, color
  transformations that this check was put in place for, so
  remove the restriction on color temp changes for low power
* This is desirable because low power situations happen often
  at times later in the day, when blasting users with blue
  light (for auto night mode) is undesirable, and because
  reducing the intensity of colors is more power efficient,
  at least for AMOLED displays

Change-Id: I6b78a3f626cff3387d2acafa9c73cdf6af208fef